### PR TITLE
Change marked dependency to use https

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "codemirror": "~5.7.0",
     "highlightjs": "~8.9.1",
-    "marked": "git@github.com:dvcrn/marked.git#checkbox-support"
+    "marked": "https://github.com/dvcrn/marked.git#checkbox-support"
   }
 }


### PR DESCRIPTION
The ssh dependency for marked (`git@github.com:dvcrn/marked.git#checkbox-support`) in `bower.json` failed on my system whereas the https version appears to work.

As an added side bonus, it also prevents extraneous entries from being added to the `~/.ssh/known_hosts` file during development.