### PR TITLE
Implement default spell-check functionality

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
     "codemirror": "~5.7.0",
+    "codemirror-spell-checker": "^1.1.1",
     "highlightjs": "~8.9.1",
     "marked": "https://github.com/dvcrn/marked.git#checkbox-support"
   }

--- a/node/ui/index.html
+++ b/node/ui/index.html
@@ -7,11 +7,13 @@
     <link href="css/github-markdown.css" rel="stylesheet"/>
     <link href="bower_components/codemirror/lib/codemirror.css" rel="stylesheet"/>
     <link href="bower_components/highlightjs/styles/github.css" rel="stylesheet"/>
+    <link href="bower_components/codemirror-spell-checker/dist/spell-checker.min.css" rel="stylesheet" />
 
     <script src="bower_components/codemirror/lib/codemirror.js"></script>
     <script src="bower_components/codemirror/addon/mode/overlay.js"></script>
     <script src="bower_components/codemirror/mode/markdown/markdown.js"></script>
     <script src="bower_components/codemirror/mode/gfm/gfm.js"></script>
+    <script src="bower_components/codemirror-spell-checker/dist/spell-checker.min.js"></script>
     <script src="bower_components/marked/lib/marked.js"></script>
     <script src="bower_components/highlightjs/highlight.pack.min.js"></script>
 </head>

--- a/src/cljs/markright/components/codemirror.cljs
+++ b/src/cljs/markright/components/codemirror.cljs
@@ -30,7 +30,8 @@
                      (let [codemirror
                            (js/CodeMirror (gdom/getElement "codemirror-target")
                                           #js {:matchBrackets true
-                                               :mode "gfm"
+                                               :mode "spell-checker"
+                                               :backdrop "gfm"
                                                :autoCloseBrackets true
                                                :lineWrapping true
                                                :lineNumbers true


### PR DESCRIPTION
Using the [codemirror-spell-checker](https://github.com/NextStepWebs/codemirror-spell-checker) package I've been able to get default spell check functionality implemented. As of yet there is no way to toggle the functionality (as I do not know clojurescript well enough to get the UI elements to modify js objects).

This should close #43.